### PR TITLE
remove unnecessary exposed port for xdebug in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
     container_name: nginx
     ports:
       - "8080:80"
-      # Port for xdebug (ensure this matches the remote_port in the xdebug.ini)
-      - "9001:9001"
     volumes:
       - ./source:/var/www/html:delegated
     depends_on:


### PR DESCRIPTION
there is no need to bind port for xdebug

see [comment](https://stackoverflow.com/a/71485900/13801805) from Derick

> You don't need "bind port" in docker-compose.yaml for Xdebug, as Xdebug does make the connection to the IDE, and hence the port does not need to be exposed for receiving connections.

I tested that xdebug works without binding a port in docker-compose.yml
